### PR TITLE
Add browser LLM chat bot with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A simple client-side task manager web application. Tasks are stored in your browser using `localStorage`.
 
-The app now supports priority levels `1-9`, comma separated tags and basic time tracking for each task. Tasks are automatically sorted by priority and high/low priority items are visually highlighted. Priority values outside the 1-9 range are clamped so invalid input never corrupts task data. An optional on-device language model integration (see `public/llm.js`) can parse natural language commands to add or edit tasks.
+The app now supports priority levels `1-9`, comma separated tags and basic time tracking for each task. Tasks are automatically sorted by priority and high/low priority items are visually highlighted. Priority values outside the 1-9 range are clamped so invalid input never corrupts task data. An optional on-device language model integration (see `public/llm.js`) can parse natural language commands to add or edit tasks. A simple chat interface (`public/chat.js`) lets you talk to the bot in the browser.
 
 ## Setup
 

--- a/public/chat.js
+++ b/public/chat.js
@@ -1,0 +1,36 @@
+function addMessage(sender, text) {
+  const div = document.createElement('div');
+  div.className = 'chat-msg';
+  div.textContent = `${sender}: ${text}`;
+  chatLog.appendChild(div);
+}
+
+async function handlePrompt(prompt) {
+  addMessage('You', prompt);
+  chatInput.value = '';
+  const response = await (window.runLLMCommand ? window.runLLMCommand(prompt) : Promise.resolve(''));
+  const text = typeof response === 'string' ? response : JSON.stringify(response);
+  addMessage('Bot', text);
+}
+
+function initChat() {
+  chatForm = document.getElementById('chat-form');
+  chatInput = document.getElementById('chat-input');
+  chatLog = document.getElementById('chat-log');
+  if (!chatForm) return;
+  chatForm.addEventListener('submit', e => {
+    e.preventDefault();
+    const prompt = chatInput.value.trim();
+    if (!prompt) return;
+    handlePrompt(prompt);
+  });
+}
+
+if (typeof document !== 'undefined') {
+  var chatForm, chatInput, chatLog;
+  document.addEventListener('DOMContentLoaded', initChat);
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = { initChat, addMessage, handlePrompt };
+}

--- a/public/index.html
+++ b/public/index.html
@@ -14,7 +14,16 @@
     <button type="submit">Add Task</button>
   </form>
   <ul id="task-list"></ul>
+  <div id="chat-container">
+    <h2>Chat Bot</h2>
+    <form id="chat-form">
+      <input type="text" id="chat-input" placeholder="Ask the bot" />
+      <button type="submit">Send</button>
+    </form>
+    <div id="chat-log"></div>
+  </div>
   <script src="script.js"></script>
   <script type="module" src="llm.js"></script>
+  <script src="chat.js"></script>
 </body>
 </html>

--- a/public/style.css
+++ b/public/style.css
@@ -8,3 +8,5 @@ button.delete { margin-left: 0.5rem; }
 button.time-add { margin-left: 0.25rem; }
 .task-item.high-priority { background-color: #ffe6e6; }
 .task-item.low-priority { opacity: 0.7; }
+#chat-container { margin-top: 2rem; }
+.chat-msg { margin: 0.25rem 0; }

--- a/tests/chat.test.js
+++ b/tests/chat.test.js
@@ -1,0 +1,39 @@
+function loadChat() {
+  jest.resetModules();
+  document.body.innerHTML = `
+    <form id="chat-form">
+      <input id="chat-input" />
+      <button type="submit">Send</button>
+    </form>
+    <div id="chat-log"></div>
+  `;
+  global.runLLMCommand = jest.fn(async p => `echo ${p}`);
+  return require('../public/chat.js');
+}
+
+describe('chat bot', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    delete global.runLLMCommand;
+  });
+
+  test('handlePrompt adds messages', async () => {
+    const { handlePrompt, initChat } = loadChat();
+    initChat();
+    await handlePrompt('hello');
+    const msgs = document.querySelectorAll('.chat-msg');
+    expect(msgs.length).toBe(2);
+    expect(msgs[0].textContent).toBe('You: hello');
+    expect(msgs[1].textContent).toBe('Bot: echo hello');
+  });
+
+  test('form submit sends prompt', async () => {
+    const { initChat } = loadChat();
+    initChat();
+    document.getElementById('chat-input').value = 'test';
+    document.getElementById('chat-form').dispatchEvent(new Event('submit'));
+    await new Promise(r => setTimeout(r, 0));
+    expect(global.runLLMCommand).toHaveBeenCalledWith('test');
+    expect(document.querySelectorAll('.chat-msg').length).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary
- build a simple chat interface for the on-device language model
- style chat container
- document the chat bot in README
- test chat features with Jest

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684b66720e5483228032d935ab81753d