### PR TITLE
Add Playwright e2e tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+test-results/

--- a/README.md
+++ b/README.md
@@ -49,3 +49,9 @@ folder. Each successful run publishes an updated version of the site.
 npm test
 ```
 
+To run end-to-end tests:
+```bash
+npm run test:e2e
+```
+
+

--- a/e2e/app.spec.js
+++ b/e2e/app.spec.js
@@ -1,0 +1,24 @@
+const { test, expect } = require('@playwright/test');
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/');
+});
+
+test('add and remove a task', async ({ page }) => {
+  await page.fill('#title', 'e2e task');
+  await page.click('#task-form button[type="submit"]');
+  await expect(page.locator('li.task-item')).toHaveCount(1);
+  await expect(page.locator('li.task-item')).toContainText('e2e task');
+  await page.click('button.delete');
+  await expect(page.locator('li.task-item')).toHaveCount(0);
+});
+
+test('time tracking persists after reload', async ({ page }) => {
+  await page.fill('#title', 'timer');
+  await page.click('#task-form button[type="submit"]');
+  await page.click('button.time-add');
+  await expect(page.locator('li.task-item .time')).toHaveText(' 5m');
+  await page.reload();
+  await expect(page.locator('li.task-item .time')).toHaveText(' 5m');
+});
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@xenova/transformers": "^2.6.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.53.0",
         "http-server": "^14.1.1",
         "jest": "^29.6.2",
         "jest-environment-jsdom": "^29.6.2"
@@ -886,6 +887,22 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.53.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.53.0.tgz",
+      "integrity": "sha512-15hjKreZDcp7t6TL/7jkAo6Df5STZN09jGiv5dbP9A6vMVncXRqE7/B2SncsyOwrkZRBH2i6/TPOL8BVmm3c7w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.53.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@protobufjs/aspromise": {
@@ -4314,6 +4331,53 @@
       "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
       "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
       "license": "MIT"
+    },
+    "node_modules/playwright": {
+      "version": "1.53.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.53.0.tgz",
+      "integrity": "sha512-ghGNnIEYZC4E+YtclRn4/p6oYbdPiASELBIYkBXfaTVKreQUYbMUYQDwS12a8F0/HtIjr/CkGjtwABeFPGcS4Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.53.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.53.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.53.0.tgz",
+      "integrity": "sha512-mGLg8m0pm4+mmtB7M89Xw/GSqoNC+twivl8ITteqvAndachozYe2ZA7srU6uleV1vEdAHYqjq+SV8SNxRRFYBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/portfinder": {
       "version": "1.0.37",

--- a/package.json
+++ b/package.json
@@ -4,15 +4,20 @@
   "description": "Simple Task Manager web app",
   "scripts": {
     "start": "http-server public",
-    "test": "jest"
+    "test": "jest",
+    "test:e2e": "playwright test"
   },
   "devDependencies": {
+    "@playwright/test": "^1.53.0",
     "http-server": "^14.1.1",
     "jest": "^29.6.2",
     "jest-environment-jsdom": "^29.6.2"
   },
   "jest": {
-    "testEnvironment": "jsdom"
+    "testEnvironment": "jsdom",
+    "testPathIgnorePatterns": [
+      "/e2e/"
+    ]
   },
   "dependencies": {
     "@xenova/transformers": "^2.6.0"

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,14 @@
+const config = {
+  testDir: 'e2e',
+  webServer: {
+    command: 'npx http-server public -p 8081',
+    port: 8081,
+    reuseExistingServer: !process.env.CI,
+  },
+  use: {
+    baseURL: 'http://localhost:8081',
+    headless: true,
+  },
+};
+
+module.exports = config;


### PR DESCRIPTION
## Summary
- add Playwright and configure web server for tests
- ignore generated test artifacts
- implement browser driven e2e tests
- document how to run the e2e suite

## Testing
- `npm test`
- `npm run test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_684b6f080cf88322b0efde0dea0717f5